### PR TITLE
Fix sscpac/chat-locker#4.  Integrate MAC restrictions (backend) into chat-locker

### DIFF
--- a/server/lib/accessManager.js
+++ b/server/lib/accessManager.js
@@ -73,6 +73,12 @@ AccessManager = function(accessProvider) {
 				];
 	};
 
+	var getClassificationOrder = function() {
+		// TODO this should be read from configurable property file
+		// lowest to highest priority
+		return ['U','C','S','TS']
+	}
+
 	// Given a list of access id's, return corresponding objects.
 	var getPermissions = function(ids) {
 		if( !_.isArray(ids) ) {
@@ -129,6 +135,11 @@ AccessManager = function(accessProvider) {
 		 * @type array of AccessPermission objects representing classifications
 		 */
 		getClassifications : getClassifications,
+		/**
+		 * Retrieve all classifications ordered from lowest to highest precedence
+		 * @type array of Clasification AccessPermission ids 
+		 */
+		getClassificationOrder : getClassificationOrder,
 		/**
 		 * Retrieve AccessPermission object(s) specified by their unique identifier
 		 * @type String or Array of Strings representing an AccessPermission to retrieve. 

--- a/server/lib/accessPermission.js
+++ b/server/lib/accessPermission.js
@@ -37,9 +37,6 @@ Jedis.AccessPermission = function(ids) {
 		? ids
 		: AccessPermissions.find({_id: {$in : ids}}).fetch();
 
-	if( perms.length !== ids.length ) {
-		throw new Error('Invalid access permission id');
-	}
 	// Group by types.
 	perms.reduce(function(o, perm) {
 		var type = perm.type;
@@ -48,31 +45,7 @@ Jedis.AccessPermission = function(ids) {
 		return o;
 	}, this);
 };
-//
-Jedis.AccessPermission.prototype.resourceClassifications = function() {
-	var classInfo = { selected:null, higher:[], lower:[] };
-	var classifications = Jedis.accessManager.getClassifications();
-	var classificationIds = _.pluck(classifications, '_id');
-	// Get the classification from the access permissions
-	var resourceClassificationIds = _.filter(_.pluck(this.classification,'_id'), function(id) {
-		return _.contains(classificationIds ,id);
-	});
-	if (resourceClassificationIds.length > 1)  {
-		console.warn('Resource permissions has more then one classifications' + resourceClassificationIds.length )
-	}
-	var resourceClassificationId = resourceClassificationIds[0];
-	_.each(classifications, function(element, index, list) {
-		var cid = element._id;
-		if (cid === resourceClassificationId) {
-			classInfo.selected = cid;
-		} else if ( ! classInfo.selected) {
-			classInfo.higher.push(cid);
-		} else {
-			classInfo.lower.push(cid);
-		}
-	});
-	return classInfo;
-};
+
 // Return a flat list of ids whose types are in the provided list (default all)
 // Design Intent: The object instance maintains the full access permission object, but in some scenarios (e.g., calls to
 // external validation service), we may need only the ids, possibly only the ids for specific types.
@@ -157,5 +130,10 @@ Jedis.AccessPermission.prototype.removeAccessIds = function(ids) {
 Jedis.AccessPermission.prototype.toString = function() {
 	return JSON.stringify(this, undefined, 4);
 };
+
+Jedis.AccessPermission.prototype.containsAll = function(permissionIds) {
+	var inCommon = _.intersection( permissionIds, this.getPermissionIds());
+	return inCommon.length === permissionIds.length
+}
 
 // vim:ts=4:sw=4:tw=120

--- a/server/lib/accessPermission.js
+++ b/server/lib/accessPermission.js
@@ -37,6 +37,9 @@ Jedis.AccessPermission = function(ids) {
 		? ids
 		: AccessPermissions.find({_id: {$in : ids}}).fetch();
 
+	if( perms.length !== ids.length ) {
+		throw new Error('Invalid access permission id');
+	}
 	// Group by types.
 	perms.reduce(function(o, perm) {
 		var type = perm.type;

--- a/server/lib/securityLabel.coffee
+++ b/server/lib/securityLabel.coffee
@@ -1,0 +1,52 @@
+###
+# SecurityLabel is a named function that will add security label access permission(s) and legacy 
+# label on messages
+# @param {Object} message - The message object
+###
+
+numberComparator = (first, second) ->
+	return first - second
+
+@Jedis.legacyLabel = (permissionIds) ->
+	template = "classification|label_field|1+0|trigraphs|SAP_SCI|release_caveats|RELTO"
+	permissions = new Jedis.AccessPermission permissionIds
+	classificationIds = permissions.getPermissionIds 'classification'
+	sapSciIds = (permissions.getPermissionIds ['SAP', 'SCI']).sort(numberComparator)
+	releaseCaveatIds = (permissions.getPermissionIds ['Release Caveat']).sort(numberComparator)
+	return template.replace('classification', classificationIds)
+		.replace('SAP_SCI', sapSciIds)
+		.replace('RELTO', releaseCaveatIds)
+
+@Jedis.securityLabelIsValid = (permissionIds) ->
+	console.log '[methods]Jedis.securityLabelIsValid -> '.green, 'permissionIds: ', permissionIds 
+	isValid = false
+	# check that ids exist
+	permissions = Jedis.accessManager.getPermissions permissionIds
+
+	isValid = permissionIds.length is permissions.length
+
+	# check that only one classification exists
+	if isValid 
+		classifications = permissions.filter (permission) ->
+			return permission?.type is 'classification'
+		isValid = classifications.length is 1
+
+	# check that system country code exists (RELTO type permission)
+	if isValid
+		isValid = _.contains( permissionIds, Meteor.settings.public.system.countryCode )
+
+	return isValid
+
+addPermissionsAndLabel = (message) ->
+	roomId = message.rid
+	room = @ChatRoom.findOne({_id: roomId});
+	# only apply to direct message and private group rooms
+	if room?.t in ['d','p']
+		message.accessPermissions = room.accessPermissions
+		message.securityLabel = room.securityLabel
+			
+	return message
+
+# Add access permission and legacy security label field to message based on Room
+# only applies to Direct message and Private group messages
+RocketChat.callbacks.add 'beforeSaveMessage', addPermissionsAndLabel

--- a/server/methods/addUserToRoom.coffee
+++ b/server/methods/addUserToRoom.coffee
@@ -1,7 +1,7 @@
 Meteor.methods
 	addUserToRoom: (data) ->
 		fromId = Meteor.userId()
-		# console.log '[methods] addUserToRoom -> '.green, 'fromId:', fromId, 'data:', data
+		console.log '[methods] addUserToRoom -> '.green, 'executor:', fromId, 'data:', data
 
 		room = ChatRoom.findOne data.rid
 
@@ -12,6 +12,14 @@ Meteor.methods
 		# verify if user is already in room
 		if room.usernames.indexOf(data.username) isnt -1
 			return
+
+		# verify user to add satisfies MAC restrictions.  Only pertains to private group
+		if room.t is 'p'
+			# chat-locker reuses the username for the _id
+			result = Meteor.call 'canAccessResource', [data.username], room.accessPermissions
+			unless result.canAccess
+				console.log '[methods] addUserToRoom -> '.red, 'User cannot be added because they have insufficient access'
+				throw new Meteor.Error 'insufficient-access', '[methods] addUserToRoom -> user has insufficient access'
 
 		now = new Date()
 

--- a/server/methods/canAccessResource.coffee
+++ b/server/methods/canAccessResource.coffee
@@ -1,0 +1,52 @@
+Meteor.methods
+	canAccessResource: (userIds, resourcePermissionIds) ->
+		# check that all users have adequate permission to a resource based on 
+		# its permissions
+		console.log '[methods] canAccessResource -> '.green, 'current user:', this.userId, 'userIds:', userIds, 'resourcePermissionIds:', resourcePermissionIds
+
+		# for security, no anonymous users
+		unless this.userId
+			console.log '[methods] canAccessResource -> '.red, 'No logged in user'
+			throw new Meteor.Error 'not-logged-user', "[methods] canAccessResource -> No anonymous user requests"
+
+		# require one or more userIds 
+		unless userIds?.length > 0
+			console.log '[methods] canAccessResource -> '.red, 'Missing userIds'
+			throw new Meteor.Error 'invalid-arguments', "[methods] canAccessResource -> UserIds not specified"
+
+		# require one or more resource permission 
+		unless resourcePermissionIds?.length > 0
+			console.log '[methods] canAccessResource -> '.red, 'Missing resource permissions'
+			throw new Meteor.Error 'invalid-arguments', "[methods] canAccessResource -> Resource Permissions not specified"
+
+		users = Meteor.users.find({_id: {$in : userIds }}).fetch()
+
+		# check for invalid userId
+		unless users?.length is userIds.length
+			console.log '[methods] canAccessResource -> '.red, 'invalid user id(s)'
+			throw new Meteor.Error 'invalid-arguments', "[methods] canAccessResource -> Invalid user id specified"
+
+		# for security, current user must have ALL permissions being checked.  Otherwise, 
+		# they could determine other user's permisions
+		canAccess = false
+		resourcePermissions = new Jedis.AccessPermission resourcePermissionIds
+		if Meteor.user?().profile?.access
+			userPermissions = new Jedis.AccessPermission Meteor.user().profile.access
+			canAccess = userPermissions.canAccessResource resourcePermissions
+
+		if canAccess is false
+			console.log '[methods] canAccessResource -> '.red, 'Current user has inadequate access permission(s)'
+			throw new Meteor.Error 'invalid-access', "[methods] canAccessResource -> Current user has inadequate access permission(s)"
+
+		# find users that do NOT have access
+		deniedUsers = _.filter users, (user) ->
+			allowed = true
+			if user?.profile?.access
+				userPermissions = new Jedis.AccessPermission user.profile.access
+				allowed = userPermissions.canAccessResource resourcePermissions   
+			# exclude users that can access the resource
+			return not allowed
+
+		canAccess = deniedUsers.length is 0
+
+		return { canAccess: canAccess, deniedUsers : _.pluck deniedUsers, '_id' };

--- a/server/methods/createPrivateGroup.coffee
+++ b/server/methods/createPrivateGroup.coffee
@@ -1,5 +1,5 @@
 Meteor.methods
-	createPrivateGroup: (name, members, accessPermissions) ->
+	createPrivateGroup: (name, members, accessPermissions = ['U','300']) ->
 		if not Meteor.userId()
 			throw new Meteor.Error 'invalid-user', "[methods] createPrivateGroup -> Invalid user"
 

--- a/server/methods/createPrivateGroup.coffee
+++ b/server/methods/createPrivateGroup.coffee
@@ -1,5 +1,5 @@
 Meteor.methods
-	createPrivateGroup: (name, members, accessPermissions = ['U','300']) ->
+	createPrivateGroup: (name, members, accessPermissions) ->
 		if not Meteor.userId()
 			throw new Meteor.Error 'invalid-user', "[methods] createPrivateGroup -> Invalid user"
 

--- a/server/methods/relabelRoom.coffee
+++ b/server/methods/relabelRoom.coffee
@@ -1,0 +1,92 @@
+Meteor.methods
+	relabelRoom: (roomId, accessPermissionIds) ->
+
+		console.log '[methods] relabelRoom -> '.green, 'current user:', this.userId, 'roomId: ', roomId, ' accessPermissionIds:', accessPermissionIds
+
+		# for security, no anonymous users
+		unless Meteor.userId()
+			console.log '[methods] relabelRoom -> '.red, 'No logged in user'
+			throw new Meteor.Error 'not-logged-user', "[methods] relabelRoom -> No anonymous user requests"
+
+		# require room id
+		unless roomId
+			console.log '[methods] relabelRoom -> '.red, 'Missing room id'
+			throw new Meteor.Error 'invalid-arguments', "[methods] relabelRoom -> room identifier not specified"
+
+		# require one or more resource permission 
+		unless accessPermissionIds?.length > 0
+			console.log '[methods] relabelRoom -> '.red, 'Missing resource permissions'
+			throw new Meteor.Error 'invalid-arguments', "[methods] relabelRoom -> Access Permission Ids not specified"
+
+		# check access permission ids are valid
+		newPermissions = new Jedis.AccessPermission(accessPermissionIds)
+		unless accessPermissionIds.length is newPermissions.toArray().length
+			console.log '[methods] relabelRoom -> '.red, 'Invalid access permission id'
+			throw new Meteor.Error 'invalid-arguments', "[methods] relabelRoom -> Received invalid access permission id"
+
+		# validate room exists
+		room = ChatRoom.findOne({_id: roomId})
+		unless room
+			console.log '[methods] relabelRoom -> '.red, 'Invalid room id'
+			throw new Meteor.Error 'invalid-arguments', "[methods] relabelRoom -> Invalid room id"
+
+		# only private groups and direct message room have labels
+		unless room.t in ['p', 'd']
+			console.log '[methods] relabelRoom -> '.red, 'Invalid room type'
+			throw new Meteor.Error 'invalid-arguments', "[methods] relabelRoom -> Invalid room type. Only private groups and direct message rooms can be labeled"
+
+		# only room members can relabel
+		unless Meteor.userId() in room.usernames
+			console.log '[methods] relabelRoom -> '.red, 'Only room members can relabel a room'
+			throw new Meteor.Error 'relabel-invalid-user', "[methods] relabelRoom -> Current user is not a room member and does not have permission to relabel the room"
+
+		# validate new permissions have classification and required Release Caveat permission(s)
+		unless Jedis.securityLabelIsValid( accessPermissionIds ) 
+			console.log '[methods] relabelRoom -> '.red, 'New access permissions are invalid.  Either too many classifications or missing required permissions'
+			throw new Meteor.Error('invalid-access-permissions', "Invalid access permissions.  Requires one classification and the system country code.")
+
+		# validate current user has the permissions they are trying to assign except for Release Caveat
+		# because user can assign ANY Release Caveat value.
+		currentUserPermissions = new Jedis.AccessPermission(Meteor.user().profile?.access)
+		unless currentUserPermissions.containsAll(newPermissions.getPermissionIds(['SAP','SCI','classification']))
+			console.log '[methods] relabelRoom -> '.red, 'Current user trying to assign permission(s) they do not have access to'
+			throw new Meteor.Error('invalid-access-permissions', "Current user does not have access to specified permission(s)")
+
+		# validate room owner still has access
+		creator = Meteor.users.findOne({_id:room.u._id})
+		creatorPermissions = new Jedis.AccessPermission( creator?.profile.access )
+		unless creatorPermissions.canAccessResource( newPermissions )
+			console.log '[methods] relabelRoom -> '.red, 'Creator not able to access room with new permissions'
+			throw new Meteor.Error('invalid-access-permissions', "Creator will not have access to room")
+
+
+		roomPermissions = new Jedis.AccessPermission(room.accessPermissions)
+
+		# check that existing SAP, SCI, RELTO permissions have not been removed
+		unless newPermissions.containsAll( roomPermissions.getPermissionIds(['SAP','SCI', 'Release Caveat']))
+			console.log '[methods] relabelRoom -> '.red, 'Removing existing SAP, SCI and Release Caveat room labels is not allowed'
+			throw new Meteor.Error 'relabel-remove-permissions', "[methods] relabelRoom -> Removing SAP, SCI, Release Caveat permissions from a room is not allowed"
+
+		# check that the classification has not been downgraded
+		newClassificationId = newPermissions.getPermissionIds('classification')?[0]
+		existingClassificationId = roomPermissions.getPermissionIds('classification')?[0]
+		unless newClassificationId is existingClassificationId
+			# classification changed so compare
+			classificationPrecedence = Jedis.accessManager.getClassificationOrder()
+			newPriority = _.indexOf(classificationPrecedence, newClassificationId)
+			existingPriority = _.indexOf(classificationPrecedence, existingClassificationId)
+
+			# this should never happen because we already verified that the permissions were valid, but check just in case 
+			if newPriority is -1 or existingPriority is -1
+				console.log '[methods] relabelRoom -> '.red, 'Classification not found when attempting to determine classification order.'
+				throw new Meteor.Error 'invalid-classification', "[methods] relabelRoom -> Invalid classification"
+
+			if newPriority < existingPriority
+				console.log '[methods] relabelRoom -> '.red, 'Classification downgraded'
+				throw new Meteor.Error 'invalid-classification', "[methods] relabelRoom -> Classification cannot be downgraded"
+
+		# whew, finally update the room with new permissions
+		ChatRoom.update( {_id: room._id}, {$set: {accessPermissions : accessPermissionIds}} )
+		console.log '[methods] relabelRoom -> '.green, 'Relabeled room: ', roomId, ' new permissions: ', accessPermissionIds
+
+		return ChatRoom.findOne({_id: room._id})


### PR DESCRIPTION
- Create canAccessResource Meteor method that checks if user(s) can access
  a resource based on a set of permissions
- add MAC checks when creating a direct message or private group.
- add permissions argument to createDirectMessage and createPrivateGroup
  Meteor methods.  permissions apply to the Room being created.
- add beforeSaveMessage hook that appends accessPermissions and
  legacySecurityLabel from parent room to newly created message.  Only
  applies to direct message and private group message because other room
  types are not MAC restricted (i.e. are public)
