### PR TITLE
Add status and statusConnection fields to imported LDAP user.

### DIFF
--- a/server/lib/directoryService.js
+++ b/server/lib/directoryService.js
@@ -103,7 +103,9 @@ Future = Npm.require('fibers/future');
                     first_name : source.givenName,
                     last_name : source.sn,
                     access : _.isArray(source.access) ? source.access : [source.access],
-                }
+                },
+                status : 'offline',
+                statusConnection : 'offline'
             }
         },
         accessPermissionLDAPMap : function(source) {


### PR DESCRIPTION
sscpac/chat-locker#48.  Set fields to 'offline' on initial import.
