### PR TITLE
Security banner cannot be clicked when viewing channel

### DIFF
--- a/client/stylesheets/base.less
+++ b/client/stylesheets/base.less
@@ -1848,9 +1848,12 @@ a.github-fork {
 		width: 100%;
 		text-align: center;
 		/* default  */
-		cursor: pointer;
+		cursor: default;
 		color:white;
 		background-color: @unclassified-background-color;
+	}
+	.security-banner.editable {
+		cursor: pointer;
 	}
 	/* jquery chosen */
 	.chzn-container-multi .chzn-choices .search-field input[type=text] {

--- a/client/views/app/room.coffee
+++ b/client/views/app/room.coffee
@@ -289,6 +289,9 @@ Template.room.helpers
 		roomData = Session.get('roomData' + this._id)
 		Template.instance().accessPermissions.set roomData?.accessPermissions
 		return Template.instance().accessPermissions
+	canEditPermissions: ->
+		roomData = Session.get('roomData' + this._id)
+		return roomData.t in ['d','p']
 
 	maxMessageLength: ->
 		return RocketChat.settings.get('Message_MaxAllowedSize')
@@ -576,6 +579,10 @@ Template.room.events
 			SideNav.setFlex "directMessagesFlex", data
 		else if roomData.t is 'p'
 			SideNav.setFlex "privateGroupsFlex", data
+		else 
+			console.log "The room's security label cannot be modified" if window.rocketDebug
+			return
+
 		SideNav.openFlex()
 		console.log "Relabel a Room: " + roomId
 

--- a/client/views/app/room.html
+++ b/client/views/app/room.html
@@ -20,7 +20,7 @@
 					{{/if}}
 				</h2>
 			</header>
-			{{> securityBanner permissions=permissions }}
+			{{> securityBanner permissions=permissions canEdit=canEditPermissions}}
 			<div class="messages-box">
 				<div class="wrapper">
 					<ul>

--- a/client/views/app/securityBanner.coffee
+++ b/client/views/app/securityBanner.coffee
@@ -2,9 +2,13 @@ Template.securityBanner.helpers
 	bannerData: -> 
 		return Template.instance().bannerData.get()
 
+	editable: ->
+		editable = Template.instance().canEdit || false
+		return if editable then 'editable' else ''
 
 Template.securityBanner.onCreated ->
 	self = this
+	this.canEdit = self.data?.canEdit || false
 	self.bannerData = new ReactiveVar {text:'Unknown', classificationId : 'U'}
 
 	self.updateBannerData = (accessPermissions) ->

--- a/client/views/app/securityBanner.html
+++ b/client/views/app/securityBanner.html
@@ -1,6 +1,6 @@
 <template name="securityBanner">
 	{{#with bannerData}}
-	<div class="security-banner {{classificationId}}">
+	<div class="security-banner {{classificationId}} {{editable}}">
 		{{text}}
 	</div>
 	{{/with}}


### PR DESCRIPTION
Security banner is clickable only for direct message and private group.  Channel is not clickable and the cursor changes to the default arrow.  
