### PR TITLE
Added call to update styles in open drop down on label/membership change

### DIFF
--- a/client/views/app/sideNav/securityLabels.js
+++ b/client/views/app/sideNav/securityLabels.js
@@ -111,6 +111,7 @@ Template.securityLabels.onCreated( function() {
 		// update currently selected labels
 		self.determineWarningOptions('.search-choice');
 		self.determineWarningOptions('.chosen-single');
+		self.determineWarningOptions(".active-result");
 	});
 
 });

--- a/client/views/app/sideNav/securityLabels.js
+++ b/client/views/app/sideNav/securityLabels.js
@@ -65,6 +65,9 @@ Template.securityLabels.onCreated( function() {
 			self.determineWarningOptions('.search-choice');
 			self.determineWarningOptions('.chosen-single');
 		}
+		else if (params.deselected) {
+			self.determineWarningOptions(".active-result");
+		}
 	};
 
 
@@ -111,7 +114,6 @@ Template.securityLabels.onCreated( function() {
 		// update currently selected labels
 		self.determineWarningOptions('.search-choice');
 		self.determineWarningOptions('.chosen-single');
-		self.determineWarningOptions(".active-result");
 	});
 
 });


### PR DESCRIPTION
In 'securityLabels.js', there is an autorun function that gets executed whenever a change to the 'warnLabelIds' reactive variable. Such changes can occur whenever there is any change to the selected members or security labels.

Before, this autorun function only acted to apply warning styles to already selected labels, but not the label options in an open drop-down menu. This is because it was assumed that any action taken to select/deselect would automatically close the drop-down menu, and we could just worry about styling it when it opened up. However, following steps in bug #59, it is possible to deselect a label while the drop-down is open, and have it stay open.

For this case, needed to make sure the drop-down results (list elements of class 'active-result') get styled when the autorun function is executed. 
