### PR TITLE
Member list should be reactive to adding users (Issue #41)

### DIFF
--- a/client/views/app/room.coffee
+++ b/client/views/app/room.coffee
@@ -195,7 +195,7 @@ Template.room.helpers
 		return {username: username, status: 'offline', customMessage: ''}
 
 	roomUsers: ->
-		room = ChatRoom.findOne(this._id, { reactive: false })
+		room = ChatRoom.findOne(this._id, { reactive: true })
 		users = []
 
 		for username in room?.usernames or []


### PR DESCRIPTION
The helper that populates the list of room members on the slide-out right pane searches the database for the room document to get the data. One search option ('reactive') specifies whether or not the returned cursor should be updated on changes to the underlying database. Setting this option to 'true' accomplishes the task of making the member list reactive.
