### PR TITLE
Fixes #44.  Set message edit/delete, show message edit/delete history

### DIFF
--- a/packages/rocketchat-lib/settings/server/startup.coffee
+++ b/packages/rocketchat-lib/settings/server/startup.coffee
@@ -38,9 +38,9 @@ Meteor.startup ->
 	RocketChat.settings.add 'SMTP_Password', '', { type: 'string', group: 'SMTP' }
 
 	RocketChat.settings.addGroup 'Message'
-	RocketChat.settings.add 'Message_AllowEditing', true, { type: 'boolean', group: 'Message', public: true }
-	RocketChat.settings.add 'Message_AllowDeleting', true, { type: 'boolean', group: 'Message', public: true }
-	RocketChat.settings.add 'Message_ShowEditedStatus', true, { type: 'boolean', group: 'Message', public: true }
+	RocketChat.settings.add 'Message_AllowEditing', false, { type: 'boolean', group: 'Message', public: true }
+	RocketChat.settings.add 'Message_AllowDeleting', false, { type: 'boolean', group: 'Message', public: true }
+	RocketChat.settings.add 'Message_ShowEditedStatus', false, { type: 'boolean', group: 'Message', public: true }
 	RocketChat.settings.add 'Message_ShowDeletedStatus', false, { type: 'boolean', group: 'Message', public: true }
 	RocketChat.settings.add 'Message_KeepHistory', false, { type: 'boolean', group: 'Message', public: true }
 	RocketChat.settings.add 'Message_MaxAllowedSize', 5000, { type: 'int', group: 'Message', public: true }


### PR DESCRIPTION
default to false in RocketChat.settings
