### PR TITLE
Fixes #83.  Disables name/members fields when editing a private group

### DIFF
--- a/client/views/app/sideNav/privateGroupsFlex.coffee
+++ b/client/views/app/sideNav/privateGroupsFlex.coffee
@@ -56,6 +56,23 @@ Template.privateGroupsFlex.helpers
 		unless Template.instance().warnUserIds.get().length is 0
 			return 'Due to security label access conflicts, some of the chosen room members will be excluded or kicked if you proceed.'
 
+	isNameDisabled: ->
+		isDisabled = false
+		# only room creator can edit name
+		room = Template.instance().room
+		if room
+			# room is undefined if we haven't loaded it yet or we're creating new room
+			isDisabled = room?.u._id isnt Meteor.userId()
+		return isDisabled
+
+	isMembersDisabled: ->
+		isDisabled = false
+		# only room creator can edit members
+		room = Template.instance().room
+		if room
+			# room is undefined if we haven't loaded it yet or we're creating new room
+			isDisabled = room?.u._id isnt Meteor.userId()
+		return isDisabled
 
 Template.privateGroupsFlex.events
 	'autocompleteselect #pvt-group-members': (event, instance, doc) ->

--- a/client/views/app/sideNav/privateGroupsFlex.html
+++ b/client/views/app/sideNav/privateGroupsFlex.html
@@ -13,16 +13,20 @@
 			{{/if}}
 			<div class="input-line">
 				<label for="pvt-group-name">{{_ "Name"}}</label>
-				<input type="text" id="pvt-group-name" class="required" dir="auto" value="{{groupName}}">
+				<input type="text" id="pvt-group-name" class="required" dir="auto" value="{{groupName}}" disabled="{{isNameDisabled}}">
 			</div>
 			<div class="input-line">
 				<label for="pvt-group-members">{{_ "Members" }}</label>
-				{{> inputAutocomplete settings=autocompleteSettings id="pvt-group-members" class="search" placeholder=tRoomMembers autocomplete="off"}}
-				<ul class="selected-users">
-					{{#each selectedUsers}}
-						<li class="selected-user" data-username="{{username}}">{{name}} <i class="icon-cancel remove-room-member"></i></li>
-					{{/each}}
-				</ul>
+				{{#if securityLabelsInitialized}}
+					{{#unless isMembersDisabled}}
+						{{> inputAutocomplete settings=autocompleteSettings id="pvt-group-members" class="search" placeholder=tRoomMembers autocomplete="off"}}
+					{{/unless}}
+					<ul class="selected-users">
+						{{#each selectedUsers}}
+							<li class="selected-user" data-username="{{username}}">{{name}} {{#unless isMembersDisabled}}<i class="icon-cancel remove-room-member"></i>{{/unless}}</li>
+						{{/each}}
+					</ul>
+				{{/if}}
 			</div>
 			{{#if securityLabelsInitialized}}
 				<div class="input-line">

--- a/server/methods/updateRoom.coffee
+++ b/server/methods/updateRoom.coffee
@@ -51,7 +51,9 @@ Meteor.methods
 
 
 		# for private groups, if any users don't have the permissions, exclude/kick them
-		if room.t is 'p'
+		# only the creator can update room name and members
+		isCreator = room.u._id is Meteor.userId()
+		if room.t is 'p' and isCreator
 
 			# update the room name, if changed
 			if displayName isnt room.displayName


### PR DESCRIPTION
Disables name/members fields when editing a private group IF the current user is NOT the group creator.  Serverside method ignores the group name and members fields if current user is not the group's creator.
