### PR TITLE
Fixes #95 Renames securityLabels field to securityLabel for direct message room.

### DIFF
--- a/server/methods/createDirectMessage.coffee
+++ b/server/methods/createDirectMessage.coffee
@@ -50,7 +50,7 @@ Meteor.methods
 				t: 'd'
 				msgs: 0
 				accessPermissions: accessPermissions
-				securityLabels: Jedis.legacyLabel accessPermissions
+				securityLabel: Jedis.legacyLabel accessPermissions
 				u:
 					_id: me.username
 


### PR DESCRIPTION
The 'beforeSaveMessage' hook sets the message's securityLabel field using
the parent room's field.  However, the parent room had securityLabels
instead of securityLabel, so the message's field was null.
