### PR TITLE
Fixes #97 Adds delimiter between username and room id when routing direct message.

### DIFF
--- a/client/lib/RoomManager.coffee
+++ b/client/lib/RoomManager.coffee
@@ -84,10 +84,10 @@ Meteor.startup ->
 					if type in ['c', 'p']
 						query.name = name
 					else if type is 'd'
+						[name, rid] = name.split(':')
 						query.usernames = $all: [Meteor.user().username, name]
 
 					room = ChatRoom.findOne query, { reactive: false }
-
 					if room?
 						openedRooms[typeName].rid = room._id
 

--- a/client/routes/roomRoute.coffee
+++ b/client/routes/roomRoute.coffee
@@ -8,7 +8,7 @@ openRoom = (type, name, rid) ->
 
 			# rid only supplied for direct messages
 			if rid
-				id = type + name + rid
+				id = type + name + ':' + rid
 			else
 				id = type + name
 			if RoomManager.open(id).ready() isnt true
@@ -23,10 +23,7 @@ openRoom = (type, name, rid) ->
 			if type is 'd'
 				query =
 					_id: rid
-				#delete query.name
-				#query.usernames =
-				#	$all: [name, Meteor.user().username]
-
+					
 			room = ChatRoom.findOne(query)
 			if not room?
 				Session.set 'roomNotFound', {type: type, name: name}


### PR DESCRIPTION
The delimiter is needed by the RoomManager to split the username and room
id apart.  Without it, the RoomManager cannot determine which room to
open, and messages are not received by other room members.
